### PR TITLE
Added unit test and unimplemented BMI 2.0 functions 

### DIFF
--- a/src/bmi/bmi.f90
+++ b/src/bmi/bmi.f90
@@ -51,26 +51,26 @@ module bmif_2_0
       procedure(bmif_get_value_int), deferred :: get_value_int
       procedure(bmif_get_value_float), deferred :: get_value_float
       procedure(bmif_get_value_double), deferred :: get_value_double
-!       procedure(bmif_get_value_ptr_int), deferred :: get_value_ptr_int
-!       procedure(bmif_get_value_ptr_float), deferred :: get_value_ptr_float
-!       procedure(bmif_get_value_ptr_double), deferred :: get_value_ptr_double
-!       procedure(bmif_get_value_at_indices_int), deferred :: &
-!            get_value_at_indices_int
-!       procedure(bmif_get_value_at_indices_float), deferred :: &
-!            get_value_at_indices_float
-!       procedure(bmif_get_value_at_indices_double), deferred :: &
-!            get_value_at_indices_double
-!
-!       ! Setters, by type
+       procedure(bmif_get_value_ptr_int), deferred :: get_value_ptr_int
+       procedure(bmif_get_value_ptr_float), deferred :: get_value_ptr_float
+       procedure(bmif_get_value_ptr_double), deferred :: get_value_ptr_double
+       procedure(bmif_get_value_at_indices_int), deferred :: &
+            get_value_at_indices_int
+       procedure(bmif_get_value_at_indices_float), deferred :: &
+            get_value_at_indices_float
+       procedure(bmif_get_value_at_indices_double), deferred :: &
+           get_value_at_indices_double
+
+       ! Setters, by type
       procedure(bmif_set_value_int), deferred :: set_value_int
       procedure(bmif_set_value_float), deferred :: set_value_float
       procedure(bmif_set_value_double), deferred :: set_value_double
-!       procedure(bmif_set_value_at_indices_int), deferred :: &
-!            set_value_at_indices_int
-!       procedure(bmif_set_value_at_indices_float), deferred :: &
-!            set_value_at_indices_float
-!       procedure(bmif_set_value_at_indices_double), deferred :: &
-!            set_value_at_indices_double
+       procedure(bmif_set_value_at_indices_int), deferred :: &
+            set_value_at_indices_int
+       procedure(bmif_set_value_at_indices_float), deferred :: &
+            set_value_at_indices_float
+       procedure(bmif_set_value_at_indices_double), deferred :: &
+            set_value_at_indices_double
 
       ! Grid information
       procedure(bmif_get_grid_rank), deferred :: get_grid_rank
@@ -290,67 +290,67 @@ module bmif_2_0
       double precision, intent(inout) :: dest(:)
       integer :: bmi_status
     end function bmif_get_value_double
-!
-!     ! Get a reference to the given integer variable.
-!     function bmif_get_value_ptr_int(this, name, dest_ptr) result(bmi_status)
-!       import :: bmi
-!       class(bmi), intent(in) :: this
-!       character(len=*), intent(in) :: name
-!       integer, pointer, intent(inout) :: dest_ptr(:)
-!       integer :: bmi_status
-!     end function bmif_get_value_ptr_int
-!
-!     ! Get a reference to the given real variable.
-!     function bmif_get_value_ptr_float(this, name, dest_ptr) result(bmi_status)
-!       import :: bmi
-!       class(bmi), intent(in) :: this
-!       character(len=*), intent(in) :: name
-!       real, pointer, intent(inout) :: dest_ptr(:)
-!       integer :: bmi_status
-!     end function bmif_get_value_ptr_float
-!
-!     ! Get a reference to the given double variable.
-!     function bmif_get_value_ptr_double(this, name, dest_ptr) result(bmi_status)
-!       import :: bmi
-!       class(bmi), intent(in) :: this
-!       character(len=*), intent(in) :: name
-!       double precision, pointer, intent(inout) :: dest_ptr(:)
-!       integer :: bmi_status
-!     end function bmif_get_value_ptr_double
-!
-!     ! Get integer values at particular (one-dimensional) indices.
-!     function bmif_get_value_at_indices_int(this, name, dest, inds) &
-!       result(bmi_status)
-!       import :: bmi
-!       class(bmi), intent(in) :: this
-!       character(len=*), intent(in) :: name
-!       integer, intent(inout) :: dest(:)
-!       integer, intent(in) :: inds(:)
-!       integer :: bmi_status
-!     end function bmif_get_value_at_indices_int
-!
-!     ! Get real values at particular (one-dimensional) indices.
-!     function bmif_get_value_at_indices_float(this, name, dest, inds) &
-!       result(bmi_status)
-!       import :: bmi
-!       class(bmi), intent(in) :: this
-!       character(len=*), intent(in) :: name
-!       real, intent(inout) :: dest(:)
-!       integer, intent(in) :: inds(:)
-!       integer :: bmi_status
-!     end function bmif_get_value_at_indices_float
-!
-!     ! Get double values at particular (one-dimensional) indices.
-!     function bmif_get_value_at_indices_double(this, name, dest, inds) &
-!       result(bmi_status)
-!       import :: bmi
-!       class(bmi), intent(in) :: this
-!       character(len=*), intent(in) :: name
-!       double precision, intent(inout) :: dest(:)
-!       integer, intent(in) :: inds(:)
-!       integer :: bmi_status
-!     end function bmif_get_value_at_indices_double
-!
+
+     ! Get a reference to the given integer variable.
+     function bmif_get_value_ptr_int(this, name, dest_ptr) result(bmi_status)
+       import :: bmi
+       class(bmi), intent(in) :: this
+       character(len=*), intent(in) :: name
+       integer, pointer, intent(inout) :: dest_ptr(:)
+       integer :: bmi_status
+     end function bmif_get_value_ptr_int
+
+     ! Get a reference to the given real variable.
+     function bmif_get_value_ptr_float(this, name, dest_ptr) result(bmi_status)
+       import :: bmi
+       class(bmi), intent(in) :: this
+       character(len=*), intent(in) :: name
+       real, pointer, intent(inout) :: dest_ptr(:)
+       integer :: bmi_status
+     end function bmif_get_value_ptr_float
+
+     ! Get a reference to the given double variable.
+     function bmif_get_value_ptr_double(this, name, dest_ptr) result(bmi_status)
+       import :: bmi
+       class(bmi), intent(in) :: this
+      character(len=*), intent(in) :: name
+       double precision, pointer, intent(inout) :: dest_ptr(:)
+       integer :: bmi_status
+     end function bmif_get_value_ptr_double
+
+     ! Get integer values at particular (one-dimensional) indices.
+     function bmif_get_value_at_indices_int(this, name, dest, inds) &
+       result(bmi_status)
+       import :: bmi
+       class(bmi), intent(in) :: this
+       character(len=*), intent(in) :: name
+       integer, intent(inout) :: dest(:)
+       integer, intent(in) :: inds(:)
+       integer :: bmi_status
+     end function bmif_get_value_at_indices_int
+
+     ! Get real values at particular (one-dimensional) indices.
+     function bmif_get_value_at_indices_float(this, name, dest, inds) &
+       result(bmi_status)
+       import :: bmi
+       class(bmi), intent(in) :: this
+       character(len=*), intent(in) :: name
+       real, intent(inout) :: dest(:)
+       integer, intent(in) :: inds(:)
+       integer :: bmi_status
+     end function bmif_get_value_at_indices_float
+
+     ! Get double values at particular (one-dimensional) indices.
+     function bmif_get_value_at_indices_double(this, name, dest, inds) &
+       result(bmi_status)
+       import :: bmi
+       class(bmi), intent(in) :: this
+      character(len=*), intent(in) :: name
+       double precision, intent(inout) :: dest(:)
+       integer, intent(in) :: inds(:)
+      integer :: bmi_status
+     end function bmif_get_value_at_indices_double
+
     ! Set new values for an integer model variable.
     function bmif_set_value_int(this, name, src) result(bmi_status)
       import :: bmi
@@ -377,40 +377,40 @@ module bmif_2_0
       double precision, intent(in) :: src(:)
       integer :: bmi_status
     end function bmif_set_value_double
-!
-!     ! Set integer values at particular (one-dimensional) indices.
-!     function bmif_set_value_at_indices_int(this, name, inds, src) &
-!       result(bmi_status)
-!       import :: bmi
-!       class(bmi), intent(inout) :: this
-!       character(len=*), intent(in) :: name
-!       integer, intent(in) :: inds(:)
-!       integer, intent(in) :: src(:)
-!       integer :: bmi_status
-!     end function bmif_set_value_at_indices_int
-!
-!     ! Set real values at particular (one-dimensional) indices.
-!     function bmif_set_value_at_indices_float(this, name, inds, src) &
-!       result(bmi_status)
-!       import :: bmi
-!       class(bmi), intent(inout) :: this
-!       character(len=*), intent(in) :: name
-!       integer, intent(in) :: inds(:)
-!       real, intent(in) :: src(:)
-!       integer :: bmi_status
-!     end function bmif_set_value_at_indices_float
-!
-!     ! Set double values at particular (one-dimensional) indices.
-!     function bmif_set_value_at_indices_double(this, name, inds, src) &
-!       result(bmi_status)
-!       import :: bmi
-!       class(bmi), intent(inout) :: this
-!       character(len=*), intent(in) :: name
-!       integer, intent(in) :: inds(:)
-!       double precision, intent(in) :: src(:)
-!       integer :: bmi_status
-!     end function bmif_set_value_at_indices_double
-!
+
+     ! Set integer values at particular (one-dimensional) indices.
+     function bmif_set_value_at_indices_int(this, name, inds, src) &
+       result(bmi_status)
+       import :: bmi
+       class(bmi), intent(inout) :: this
+       character(len=*), intent(in) :: name
+       integer, intent(in) :: inds(:)
+       integer, intent(in) :: src(:)
+       integer :: bmi_status
+     end function bmif_set_value_at_indices_int
+
+     ! Set real values at particular (one-dimensional) indices.
+     function bmif_set_value_at_indices_float(this, name, inds, src) &
+       result(bmi_status)
+       import :: bmi
+       class(bmi), intent(inout) :: this
+       character(len=*), intent(in) :: name
+       integer, intent(in) :: inds(:)
+       real, intent(in) :: src(:)
+       integer :: bmi_status
+     end function bmif_set_value_at_indices_float
+
+     ! Set double values at particular (one-dimensional) indices.
+     function bmif_set_value_at_indices_double(this, name, inds, src) &
+       result(bmi_status)
+       import :: bmi
+       class(bmi), intent(inout) :: this
+       character(len=*), intent(in) :: name
+       integer, intent(in) :: inds(:)
+       double precision, intent(in) :: src(:)
+       integer :: bmi_status
+     end function bmif_set_value_at_indices_double
+
     ! Get number of dimensions of the computational grid.
     function bmif_get_grid_rank(this, grid, rank) result(bmi_status)
       import :: bmi

--- a/src/bmi/bmi_snow17.f90
+++ b/src/bmi/bmi_snow17.f90
@@ -59,20 +59,20 @@ module bmi_snow17_module
           get_value_int, &
           get_value_float, &
           get_value_double
-!      procedure :: get_value_ptr_int => snow17_get_ptr_int
-!      procedure :: get_value_ptr_float => snow17_get_ptr_float
-!      procedure :: get_value_ptr_double => snow17_get_ptr_double
-!      generic :: get_value_ptr => &
-!           get_value_ptr_int, &
-!           get_value_ptr_float, &
-!           get_value_ptr_double
-!      procedure :: get_value_at_indices_int => snow17_get_at_indices_int
-!      procedure :: get_value_at_indices_float => snow17_get_at_indices_float
-!      procedure :: get_value_at_indices_double => snow17_get_at_indices_double
-!      generic :: get_value_at_indices => &
-!           get_value_at_indices_int, &
-!           get_value_at_indices_float, &
-!           get_value_at_indices_double
+      procedure :: get_value_ptr_int => snow17_get_ptr_int
+      procedure :: get_value_ptr_float => snow17_get_ptr_float
+      procedure :: get_value_ptr_double => snow17_get_ptr_double
+      generic :: get_value_ptr => &
+           get_value_ptr_int, &
+           get_value_ptr_float, &
+           get_value_ptr_double
+      procedure :: get_value_at_indices_int => snow17_get_at_indices_int
+      procedure :: get_value_at_indices_float => snow17_get_at_indices_float
+      procedure :: get_value_at_indices_double => snow17_get_at_indices_double
+      generic :: get_value_at_indices => &
+           get_value_at_indices_int, &
+           get_value_at_indices_float, &
+           get_value_at_indices_double
      procedure :: set_value_int => snow17_set_int
      procedure :: set_value_float => snow17_set_float
      procedure :: set_value_double => snow17_set_double
@@ -80,13 +80,13 @@ module bmi_snow17_module
           set_value_int, &
           set_value_float, &
           set_value_double
-!      procedure :: set_value_at_indices_int => snow17_set_at_indices_int
-!      procedure :: set_value_at_indices_float => snow17_set_at_indices_float
-!      procedure :: set_value_at_indices_double => snow17_set_at_indices_double
-!      generic :: set_value_at_indices => &
-!           set_value_at_indices_int, &
-!           set_value_at_indices_float, &
-!           set_value_at_indices_double
+      procedure :: set_value_at_indices_int => snow17_set_at_indices_int
+      procedure :: set_value_at_indices_float => snow17_set_at_indices_float
+      procedure :: set_value_at_indices_double => snow17_set_at_indices_double
+      generic :: set_value_at_indices => &
+           set_value_at_indices_int, &
+           set_value_at_indices_float, &
+           set_value_at_indices_double
 !      procedure :: print_model_info
   end type bmi_snow17
 
@@ -701,22 +701,22 @@ contains
 
     select case(name)
     case("precip")
-       dest = sizeof(this%model%forcing%precip_comb)    ! 'sizeof' in gcc & ifort
+       dest(1) = this%model%forcing%precip_comb
        bmi_status = BMI_SUCCESS
     case("tair")
-       dest = sizeof(this%model%forcing%tair_comb)      ! 'sizeof' in gcc & ifort
+       dest(1) = this%model%forcing%tair_comb
        bmi_status = BMI_SUCCESS
     case("precip_scf")
-       dest = sizeof(this%model%forcing%precip_scf_comb)     ! 'sizeof' in gcc & ifort
+       dest(1) = this%model%forcing%precip_scf_comb
        bmi_status = BMI_SUCCESS
     case("sneqv")
-       dest = sizeof(this%model%modelvar%sneqv_comb)     ! 'sizeof' in gcc & ifort
+       dest(1) = this%model%modelvar%sneqv_comb
        bmi_status = BMI_SUCCESS
     case("snowh")
-       dest = sizeof(this%model%modelvar%snowh_comb)     ! 'sizeof' in gcc & ifort
+       dest(1) = this%model%modelvar%snowh_comb
        bmi_status = BMI_SUCCESS
     case("raim")
-       dest = sizeof(this%model%modelvar%raim_comb)      ! 'sizeof' in gcc & ifort
+       dest(1) = this%model%modelvar%raim_comb
        bmi_status = BMI_SUCCESS
     case default
        dest(:) = -1.0
@@ -744,124 +744,110 @@ contains
 
 ! !=================== get_value_ptr functions not implemented yet =================
 
-!   ! Get a reference to an integer-valued variable, flattened.
-!   function snow17_get_ptr_int(this, name, dest_ptr) result (bmi_status)
-!     class (bmi_snow17), intent(in) :: this
-!     character (len=*), intent(in) :: name
-!     integer, pointer, intent(inout) :: dest_ptr(:)
-!     integer :: bmi_status
-!     type (c_ptr) :: src
-!     integer :: n_elements
-!
-! !==================== UPDATE IMPLEMENTATION IF NECESSARY FOR INTEGER VARS =================
-!
-!     select case(name)
-!     case default
-!        bmi_status = BMI_FAILURE
-!     end select
-!   end function snow17_get_ptr_int
-!
-!   ! Get a reference to a real-valued variable, flattened.
-!   function snow17_get_ptr_float(this, name, dest_ptr) result (bmi_status)
-!     class (bmi_snow17), intent(in) :: this
-!     character (len=*), intent(in) :: name
-!     real, pointer, intent(inout) :: dest_ptr(:)
-!     integer :: bmi_status, status
-!     type (c_ptr) :: src
-!     integer :: n_elements, gridid
-!
-!     select case(name)
-!     case("SFCPRS")
-!        src = c_loc(this%model%forcing%sfcprs)
-!        status = this%get_var_grid(name,gridid)
-!        status = this%get_grid_size(gridid, n_elements)
-!        call c_f_pointer(src, dest_ptr, [n_elements])
-!        bmi_status = BMI_SUCCESS
-!     case default
-!        bmi_status = BMI_FAILURE
-!     end select
-!   end function snow17_get_ptr_float
-!
-!   ! Get a reference to an double-valued variable, flattened.
-!   function snow17_get_ptr_double(this, name, dest_ptr) result (bmi_status)
-!     class (bmi_snow17), intent(in) :: this
-!     character (len=*), intent(in) :: name
-!     double precision, pointer, intent(inout) :: dest_ptr(:)
-!     integer :: bmi_status
-!     type (c_ptr) :: src
-!     integer :: n_elements
-!
-! !==================== UPDATE IMPLEMENTATION IF NECESSARY FOR DOUBLE VARS =================\
-!
-!     select case(name)
-!     case default
-!        bmi_status = BMI_FAILURE
-!     end select
-!   end function snow17_get_ptr_double
-!
-!   ! Get values of an integer variable at the given locations.
-!   function snow17_get_at_indices_int(this, name, dest, inds) &
-!        result (bmi_status)
-!     class (bmi_snow17), intent(in) :: this
-!     character (len=*), intent(in) :: name
-!     integer, intent(inout) :: dest(:)
-!     integer, intent(in) :: inds(:)
-!     integer :: bmi_status
-!     type (c_ptr) src
-!     integer, pointer :: src_flattened(:)
-!     integer :: i, n_elements
-!
-!     select case(name)
-!     case default
-!        bmi_status = BMI_FAILURE
-!     end select
-!   end function snow17_get_at_indices_int
-!
-!   ! Get values of a real variable at the given locations.
-!   function snow17_get_at_indices_float(this, name, dest, inds) &
-!        result (bmi_status)
-!     class (bmi_snow17), intent(in) :: this
-!     character (len=*), intent(in) :: name
-!     real, intent(inout) :: dest(:)
-!     integer, intent(in) :: inds(:)
-!     integer :: bmi_status
-!     type (c_ptr) src
-!     real, pointer :: src_flattened(:)
-!     integer :: i, n_elements
-!
-!     select case(name)
-!     case("plate_surface__temperature")
-!        src = c_loc(this%model%temperature(1,1))
-!        call c_f_pointer(src, src_flattened, [this%model%n_y * this%model%n_x])
-!        n_elements = size(inds)
-!        do i = 1, n_elements
-!           dest(i) = src_flattened(inds(i))
-!        end do
-!        bmi_status = BMI_SUCCESS
-!     case default
-!        bmi_status = BMI_FAILURE
-!     end select
-!   end function snow17_get_at_indices_float
-!
-!   ! Get values of a double variable at the given locations.
-!   function snow17_get_at_indices_double(this, name, dest, inds) &
-!        result (bmi_status)
-!     class (bmi_snow17), intent(in) :: this
-!     character (len=*), intent(in) :: name
-!     double precision, intent(inout) :: dest(:)
-!     integer, intent(in) :: inds(:)
-!     integer :: bmi_status
-!     type (c_ptr) src
-!     double precision, pointer :: src_flattened(:)
-!     integer :: i, n_elements
-!
-!     select case(name)
-!     case default
-!        bmi_status = BMI_FAILURE
-!     end select
-!   end function snow17_get_at_indices_double
-!
-  ! Set new integer values.
+   ! Get a reference to an integer-valued variable, flattened.
+   function snow17_get_ptr_int(this, name, dest_ptr) result (bmi_status)
+     class (bmi_snow17), intent(in) :: this
+     character (len=*), intent(in) :: name
+     integer, pointer, intent(inout) :: dest_ptr(:)
+     integer :: bmi_status
+     type (c_ptr) :: src
+     integer :: n_elements
+
+ !==================== UPDATE IMPLEMENTATION IF NECESSARY FOR INTEGER VARS =================
+
+     select case(name)
+     case default
+        bmi_status = BMI_FAILURE
+     end select
+   end function snow17_get_ptr_int
+
+   ! Get a reference to a real-valued variable, flattened.
+   function snow17_get_ptr_float(this, name, dest_ptr) result (bmi_status)
+     class (bmi_snow17), intent(in) :: this
+     character (len=*), intent(in) :: name
+     real, pointer, intent(inout) :: dest_ptr(:)
+    integer :: bmi_status, status
+     type (c_ptr) :: src
+     integer :: n_elements, gridid
+
+     select case(name)
+     case default
+        bmi_status = BMI_FAILURE
+     end select
+   end function snow17_get_ptr_float
+
+   ! Get a reference to an double-valued variable, flattened.
+   function snow17_get_ptr_double(this, name, dest_ptr) result (bmi_status)
+     class (bmi_snow17), intent(in) :: this
+     character (len=*), intent(in) :: name
+     double precision, pointer, intent(inout) :: dest_ptr(:)
+     integer :: bmi_status
+     type (c_ptr) :: src
+     integer :: n_elements
+
+ !==================== UPDATE IMPLEMENTATION IF NECESSARY FOR DOUBLE VARS =================\
+
+     select case(name)
+     case default
+        bmi_status = BMI_FAILURE
+     end select
+   end function snow17_get_ptr_double
+
+   ! Get values of an integer variable at the given locations.
+   function snow17_get_at_indices_int(this, name, dest, inds) &
+        result (bmi_status)
+     class (bmi_snow17), intent(in) :: this
+     character (len=*), intent(in) :: name
+     integer, intent(inout) :: dest(:)
+     integer, intent(in) :: inds(:)
+     integer :: bmi_status
+     type (c_ptr) src
+     integer, pointer :: src_flattened(:)
+     integer :: i, n_elements
+
+     select case(name)
+     case default
+        bmi_status = BMI_FAILURE
+     end select
+   end function snow17_get_at_indices_int
+
+   ! Get values of a real variable at the given locations.
+   function snow17_get_at_indices_float(this, name, dest, inds) &
+        result (bmi_status)
+     class (bmi_snow17), intent(in) :: this
+    character (len=*), intent(in) :: name
+     real, intent(inout) :: dest(:)
+     integer, intent(in) :: inds(:)
+     integer :: bmi_status
+     type (c_ptr) src
+     real, pointer :: src_flattened(:)
+     integer :: i, n_elements
+
+     select case(name)
+     case default
+        bmi_status = BMI_FAILURE
+     end select
+   end function snow17_get_at_indices_float
+
+   ! Get values of a double variable at the given locations.
+   function snow17_get_at_indices_double(this, name, dest, inds) &
+        result (bmi_status)
+     class (bmi_snow17), intent(in) :: this
+     character (len=*), intent(in) :: name
+     double precision, intent(inout) :: dest(:)
+     integer, intent(in) :: inds(:)
+     integer :: bmi_status
+     type (c_ptr) src
+     double precision, pointer :: src_flattened(:)
+     integer :: i, n_elements
+
+     select case(name)
+     case default
+        bmi_status = BMI_FAILURE
+     end select
+   end function snow17_get_at_indices_double
+
+ ! Set new integer values.
   function snow17_set_int(this, name, src) result (bmi_status)
     class (bmi_snow17), intent(inout) :: this
     character (len=*), intent(in) :: name
@@ -926,68 +912,61 @@ contains
        bmi_status = BMI_FAILURE
     end select
   end function snow17_set_double
-!
-!   ! Set integer values at particular locations.
-!   function snow17_set_at_indices_int(this, name, inds, src) &
-!        result (bmi_status)
-!     class (bmi_snow17), intent(inout) :: this
-!     character (len=*), intent(in) :: name
-!     integer, intent(in) :: inds(:)
-!     integer, intent(in) :: src(:)
-!     integer :: bmi_status
-!     type (c_ptr) dest
-!     integer, pointer :: dest_flattened(:)
-!     integer :: i
-!
-!     select case(name)
-!     case default
-!        bmi_status = BMI_FAILURE
-!     end select
-!   end function snow17_set_at_indices_int
-!
-!   ! Set real values at particular locations.
-!   function snow17_set_at_indices_float(this, name, inds, src) &
-!        result (bmi_status)
-!     class (bmi_snow17), intent(inout) :: this
-!     character (len=*), intent(in) :: name
-!     integer, intent(in) :: inds(:)
-!     real, intent(in) :: src(:)
-!     integer :: bmi_status
-!     type (c_ptr) dest
-!     real, pointer :: dest_flattened(:)
-!     integer :: i
-!
-!     select case(name)
-!     case("plate_surface__temperature")
-!        dest = c_loc(this%model%temperature(1,1))
-!        call c_f_pointer(dest, dest_flattened, [this%model%n_y * this%model%n_x])
-!        do i = 1, size(inds)
-!           dest_flattened(inds(i)) = src(i)
-!        end do
-!        bmi_status = BMI_SUCCESS
-!     case default
-!        bmi_status = BMI_FAILURE
-!     end select
-!   end function snow17_set_at_indices_float
-!
-!   ! Set double values at particular locations.
-!   function snow17_set_at_indices_double(this, name, inds, src) &
-!        result (bmi_status)
-!     class (bmi_snow17), intent(inout) :: this
-!     character (len=*), intent(in) :: name
-!     integer, intent(in) :: inds(:)
-!     double precision, intent(in) :: src(:)
-!     integer :: bmi_status
-!     type (c_ptr) dest
-!     double precision, pointer :: dest_flattened(:)
-!     integer :: i
-!
-!     select case(name)
-!     case default
-!        bmi_status = BMI_FAILURE
-!     end select
-!   end function snow17_set_at_indices_double
-!
+
+   ! Set integer values at particular locations.
+   function snow17_set_at_indices_int(this, name, inds, src) &
+        result (bmi_status)
+     class (bmi_snow17), intent(inout) :: this
+     character (len=*), intent(in) :: name
+     integer, intent(in) :: inds(:)
+     integer, intent(in) :: src(:)
+     integer :: bmi_status
+     type (c_ptr) dest
+     integer, pointer :: dest_flattened(:)
+     integer :: i
+
+     select case(name)
+     case default
+        bmi_status = BMI_FAILURE
+     end select
+   end function snow17_set_at_indices_int
+
+   ! Set real values at particular locations.
+   function snow17_set_at_indices_float(this, name, inds, src) &
+        result (bmi_status)
+     class (bmi_snow17), intent(inout) :: this
+     character (len=*), intent(in) :: name
+     integer, intent(in) :: inds(:)
+     real, intent(in) :: src(:)
+     integer :: bmi_status
+     type (c_ptr) dest
+     real, pointer :: dest_flattened(:)
+     integer :: i
+
+     select case(name)
+     case default
+        bmi_status = BMI_FAILURE
+     end select
+   end function snow17_set_at_indices_float
+
+   ! Set double values at particular locations.
+   function snow17_set_at_indices_double(this, name, inds, src) &
+        result (bmi_status)
+     class (bmi_snow17), intent(inout) :: this
+     character (len=*), intent(in) :: name
+     integer, intent(in) :: inds(:)
+     double precision, intent(in) :: src(:)
+     integer :: bmi_status
+     type (c_ptr) dest
+     double precision, pointer :: dest_flattened(:)
+     integer :: i
+
+     select case(name)
+     case default
+        bmi_status = BMI_FAILURE
+     end select
+   end function snow17_set_at_indices_double
+
 !   ! A non-BMI helper routine to advance the model by a fractional time step.
 !   subroutine update_frac(this, time_frac)
 !     class (bmi_snow17), intent(inout) :: this

--- a/src/share/ioModule.f90
+++ b/src/share/ioModule.f90
@@ -96,37 +96,39 @@ contains
             read(readline, *, iostat=ios) this%daygm
             n_params_read = n_params_read + 1
           case ('adc1')
-            read(readline, *, iostat=ios) this%adc(:,1)
+            !read(readline, *, iostat=ios) this%adc(:,1)
+            read(readline, *, iostat=ios) this%adc(1,:)
             n_params_read = n_params_read + 1
           case ('adc2')
-            read(readline, *, iostat=ios) this%adc(:,2)
+            !read(readline, *, iostat=ios) this%adc(:,2)
+            read(readline, *, iostat=ios) this%adc(2,:)
             n_params_read = n_params_read + 1
           case ('adc3')
-            read(readline, *, iostat=ios) this%adc(:,3)
+            read(readline, *, iostat=ios) this%adc(3,:)
             n_params_read = n_params_read + 1
           case ('adc4')
-            read(readline, *, iostat=ios) this%adc(:,4)
+            read(readline, *, iostat=ios) this%adc(4,:)
             n_params_read = n_params_read + 1
           case ('adc5')
-            read(readline, *, iostat=ios) this%adc(:,5)
+            read(readline, *, iostat=ios) this%adc(5,:)
             n_params_read = n_params_read + 1
           case ('adc6')
-            read(readline, *, iostat=ios) this%adc(:,6)
+            read(readline, *, iostat=ios) this%adc(6,:)
             n_params_read = n_params_read + 1
           case ('adc7')
-            read(readline, *, iostat=ios) this%adc(:,7)
+            read(readline, *, iostat=ios) this%adc(7,:)
             n_params_read = n_params_read + 1
           case ('adc8')
-            read(readline, *, iostat=ios) this%adc(:,8)
+            read(readline, *, iostat=ios) this%adc(8,:)
             n_params_read = n_params_read + 1
           case ('adc9')
-            read(readline, *, iostat=ios) this%adc(:,9)
+            read(readline, *, iostat=ios) this%adc(9,:)
             n_params_read = n_params_read + 1
           case ('adc10')
-            read(readline, *, iostat=ios) this%adc(:,10)
+            read(readline, *, iostat=ios) this%adc(10,:)
             n_params_read = n_params_read + 1
           case ('adc11')
-            read(readline, *, iostat=ios) this%adc(:,11)
+            read(readline, *, iostat=ios) this%adc(11,:)
             n_params_read = n_params_read + 1
           case default
             print *, 'Parameter ',param,' not recognized in snow file'
@@ -329,6 +331,7 @@ contains
         ! make filename to read
         filename = trim(namelist%output_root) // trim(parameters%hru_id(nh)) // '.txt'	
 
+        write(*,*) "open fileunit: ", nh+1
         ! Open the output files
         open(runinfo%output_fileunits(nh+1), file = trim(filename), form = 'formatted', action = 'write', status='replace', iostat = ierr)
         if (ierr /= 0) then
@@ -400,7 +403,7 @@ contains
     ! write fixed-width format line of state file for current timesstep and sub-unit
     41 FORMAT(I0.4, 3(I0.2), 20(F20.12))    ! use maximum precision (for double)
     write(runinfo%state_fileunits(n_curr_hru), 41, iostat=ierr) runinfo%curr_yr, runinfo%curr_mo, runinfo%curr_dy, runinfo%curr_hr, &
-          modelvar%tprev(n_curr_hru), modelvar%cs(n_curr_hru,:)
+          modelvar%tprev(n_curr_hru), modelvar%cs(:,n_curr_hru)
     if(ierr /= 0) then
       print*, 'ERROR writing state file information for sub-unit ', n_curr_hru; stop
     endif
@@ -459,7 +462,7 @@ contains
       ! read each row and check to see if the date matches the initial state date
       do while(ios .eq. 0)
   
-        read(95, *, IOSTAT=ios) statefile_datehr, modelvar%tprev(hru), modelvar%cs(hru,:)
+        read(95, *, IOSTAT=ios) statefile_datehr, modelvar%tprev(hru), modelvar%cs(:,hru)
   
         ! checks either for real date or special keyword identifying the state to use
         !   this functionality facilitates ESP forecast initialization

--- a/src/share/modelVarType.f90
+++ b/src/share/modelVarType.f90
@@ -42,7 +42,8 @@ module modelVarType
     allocate(this%snowh (1:namelist%n_hrus))
     allocate(this%snow  (1:namelist%n_hrus))
     allocate(this%tprev (1:namelist%n_hrus))
-    allocate(this%cs    (1:namelist%n_hrus, 1:19))
+    !allocate(this%cs    (1:namelist%n_hrus, 1:19))
+    allocate(this%cs    (1:19, 1:namelist%n_hrus))
     
     ! -- default assignments
     this%raim(:)       = 0.0

--- a/src/share/parametersType.f90
+++ b/src/share/parametersType.f90
@@ -52,7 +52,8 @@ contains
     allocate(this%mbase(n_hrus))
     allocate(this%plwhc(n_hrus))
     allocate(this%daygm(n_hrus))    
-    allocate(this%adc(n_hrus, 11))    ! 11 points (0.0 to 1.0 in 0.1 increments)
+    !allocate(this%adc(n_hrus, 11))    ! 11 points (0.0 to 1.0 in 0.1 increments)
+    allocate(this%adc(11,n_hrus))    ! 11 points (0.0 to 1.0 in 0.1 increments)
     
     ! assign defaults (if any)
     this%total_area  = huge(1.0)

--- a/src/share/runSnow17.f90
+++ b/src/share/runSnow17.f90
@@ -147,9 +147,9 @@ contains
   	      parameters%latitude(nh), parameters%scf(nh), parameters%mfmax(nh), parameters%mfmin(nh), &
           parameters%uadj(nh), parameters%si(nh), parameters%nmf(nh), parameters%tipm(nh), parameters%mbase(nh), &
           parameters%pxtemp(nh), parameters%plwhc(nh), parameters%daygm(nh), parameters%elev(nh), forcing%pa(nh), &
-          parameters%adc(nh,:), &
+          parameters%adc(:,nh), &
           ! SNOW17 CARRYOVER VARIABLES
-  		  modelvar%cs(nh,:), modelvar%tprev(nh) )             
+  		  modelvar%cs(:,nh), modelvar%tprev(nh) )             
 
         !---------------------------------------------------------------------
         ! add results to output file if NGEN_OUTPUT_ACTIVE is undefined
@@ -192,7 +192,10 @@ contains
       close(model%runinfo%forcing_fileunits(nh))
       close(model%runinfo%output_fileunits(nh))
     end do
-    close(model%runinfo%output_fileunits(nh+1))        ! combined output file (basin avg)
+    !
+    !
+    ! Now 'nh' value is (runinfo%n_hrus + 1)
+    close(model%runinfo%output_fileunits(nh)) ! combined output file (basin avg)
 
 #endif
 

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -1,0 +1,79 @@
+# Makefile
+#
+.SUFFIXES:
+.SUFFIXES: .o .f90
+
+F90   = gfortran
+
+FREESOURCE     =       -ffree-form  -ffree-line-length-none
+#F90FLAGS       =   -O3 -g -fbacktrace -Wall -fcheck=all -fdefault-real-8 -fno-align-commons -ffree-line-length-none -cpp
+F90FLAGS = -O3 -g -fbacktrace -Wall -fdefault-real-8 -fno-align-commons -ffree-line-length-none -cpp
+CPP            =       cpp
+CPPFLAGS       =       -P -traditional -D_GFORTRAN_
+
+# --- snow-19 code (fortran 90, different options)
+snow19_objs = \
+		zero19.o \
+		rout19.o \
+		aesc19.o \
+		melt19.o \
+		SNEW.o \
+		SNOWT.o \
+		SNOWPACK.o \
+		adjc19.o \
+		aeco19.o \
+		updt19.o \
+		SNDEPTH.o \
+		PACK19.o \
+		exsnow19.o
+
+# -- share utilities and code used by the driver in running the model
+run_util_objs = \
+	nrtype.o \
+	constants.o \
+	namelistModule.o \
+        parametersType.o \
+        forcingType.o \
+        dateTimeUtilsModule.o \
+        runInfoType.o \
+        modelVarType.o \
+        ioModule.o \
+        runSnow17.o 
+
+bmi_functions_objs = bmi.o \
+		bmi_snow17.o
+
+CMD = snow17_driver_test.exe
+
+all:	$(CMD)
+
+$(CMD): $(bmi_functions_objs) $(snow19_objs) $(run_util_objs) \
+      	snow17_driver_test.o
+	$(F90) -fPIC -o $(@) -I./ snow17_driver_test.o \
+		$(bmi_functions_objs) $(snow19_objs) $(run_util_objs)
+
+$(bmi_functions_objs): $(run_util_objs)
+
+$(snow19_objs): $(run_util_objs)
+
+snow17_driver_test.o: snow17_driver_test.f90
+	$(F90) -c $(F90FLAGS) $(FREESOURCE) -I./ snow17_driver_test.f90 
+
+$(bmi_functions_objs): %.o: ../../src/bmi/%.f90
+	$(F90) -c $(F90FLAGS) $(FREESOURCE) -I./ $< 
+
+$(run_util_objs): %.o: ../../src/share/%.f90
+	$(F90) -c $(F90FLAGS) $(FREESOURCE) -I./ $<
+
+$(snow19_objs): %.o: ../../src/snow19/%.f
+	$(F90) -c $(F90FLAGS) -I./ $<
+
+test: $(CMD)
+	cd ../../test_cases; tar -zxvf ex1.tgz; \
+        cd ex1/run; \
+	../../../src/test/snow17_driver_test.exe ./namelist.bmi.HHWM8
+
+# This command cleans up
+clean:
+	rm -f *.mod *.o $(CMD)
+

--- a/src/test/README.md
+++ b/src/test/README.md
@@ -1,0 +1,10 @@
+# Unit testing instructions
+
+1. Follow the instructions in INSTALL.md to install the program.
+2. Change directory to the test directory: `cd snow17/src/test`
+3. Run `make` to compile the unit testing program and generate the executable, which is `snow17/src/test/snow17_driver_test.exe`
+4. Run `make test` to run the unit tests using the example test case in `snow17/test_cases`. 
+5. Steps 3 and 4 can be combined into one by issuing the command `make test` under `snow17/src/test`.
+6. Check the screen print out to see if the tests pass. 
+
+Note that a `gfortran` compiler is assumed here. To change it to another compiler, modify the `F90` variable in the `Makefile` and corresponding `F90FLAGS` and `CPPFLAGS`.

--- a/src/test/snow17_driver_test.f90
+++ b/src/test/snow17_driver_test.f90
@@ -1,0 +1,331 @@
+!
+! This program tests the BMI functionality in Fortran
+! The generic code can be used in any BMI-implemented Fortran model
+! 
+! Adapted by Zhengtao Cui (Zhengtao.Cui@noaa.gov) from the noah-owp-modular
+! unit testing code at https://github.com/NOAA-OWP/noah-owp-modular.git 
+! 
+! Added the unimplemented BMI 2.0 functions to be BMI 2.0 compliant. These
+! functions will return `BMI_FAILURE` once envoked.
+!
+
+program snow17_driver_test
+
+  !---------------------------------------------------------------------
+  !  Modules
+  !  Change from non-BMI: Only BMI modules need to be exposed
+  !  The rest are used in ../src/NoahMPSurfaceModule.f90
+  !---------------------------------------------------------------------
+  use bmi_snow17_module
+  use bmif_2_0
+  use dateTimeUtilsModule
+
+  implicit none
+
+  !---------------------------------------------------------------------
+  !  Types
+  !  Change from non-BMI: only the bmi_noahowp type needed
+  !  Forcing, Energy, Water, etc. not needed
+  !---------------------------------------------------------------------
+    type (bmi_snow17)  :: m
+  
+  !---------------------------------------------------------------------
+  !  Local variable(s) for BMI testing
+  !---------------------------------------------------------------------
+    character (len = 80)                              :: arg              ! command line argument for config file
+    integer                                           :: status           ! returning status values
+    character (len = BMI_MAX_COMPONENT_NAME), pointer :: component_name   ! component name
+    integer                                           :: count            ! var counts
+    character (len = BMI_MAX_VAR_NAME), pointer       :: names_inputs(:)  ! var names
+    character (len = BMI_MAX_VAR_NAME), pointer       :: names_outputs(:) ! var names
+    integer                                           :: n_inputs         ! n input vars
+    integer                                           :: n_outputs        ! n output vars
+    integer                                           :: iBMI             ! loop counter
+    character (len = 20)                              :: var_type         ! name of variable type
+    character (len = 10)                              :: var_units        ! variable units
+    integer                                           :: var_itemsize     ! memory size per var array element
+    integer                                           :: var_nbytes       ! memory size over full var array
+    double precision                                  :: timestep         ! timestep
+    double precision                                  :: bmi_time         ! time output from BMI functions
+    double precision                                  :: time_until       ! time to which update until should run
+    double precision                                  :: end_time         ! time of last model time step
+    double precision                                  :: current_time     ! current model time
+    character (len = 1)                               :: ts_units         ! timestep units
+    real, allocatable, target                         :: var_value_get(:) ! value of a variable
+    real, allocatable                                 :: var_value_set(:) ! value of a variable
+    integer                                           :: grid_int         ! grid value
+    character (len = 20)                              :: grid_type        ! name of grid type
+    integer                                           :: grid_rank        ! rank of grid
+    integer, dimension(2)                             :: grid_shape       ! shape of grid (change dims if not X * Y grid)
+    integer                                           :: j                ! generic index
+    integer                                           :: grid_size        ! size of grid (ie. nX * nY)
+    double precision, dimension(2)                    :: grid_spacing     ! resolution of grid in X & Y (change dims if not X * Y grid)
+    double precision, dimension(2)                    :: grid_origin      ! X & Y origin of grid (change dims if not X * Y grid)
+    double precision, dimension(1)                    :: grid_x           ! X coordinate of grid nodes (change dims if multiple nodes)
+    double precision, dimension(1)                    :: grid_y           ! Y coordinate of grid nodes (change dims if multiple nodes)
+    double precision, dimension(1)                    :: grid_z           ! Y coordinate of grid nodes (change dims if multiple nodes)
+    
+    real, pointer                                 :: var_value_get_ptr(:) ! value of a variable for get_value_ptr
+
+    integer, dimension(3)                             :: grid_indices       ! grid indices (change dims as needed)
+  !---------------------------------------------------------------------
+  !  Initialize
+  !---------------------------------------------------------------------
+    print*, "Initializing..."
+    call get_command_argument(1, arg)
+    status = m%initialize(arg)
+
+  !---------------------------------------------------------------------
+  ! Get model information
+  ! component_name and input/output_var
+  !---------------------------------------------------------------------
+    status = m%get_component_name(component_name)
+    print*, "Component name = ", trim(component_name)
+
+    status = m%get_input_item_count(count)
+    print*, "Total input vars = ", count
+    n_inputs = count
+
+    status = m%get_output_item_count(count)
+    print*, "Total output vars = ", count
+    n_outputs = count
+
+    status = m%get_input_var_names(names_inputs)
+    do iBMI = 1, n_inputs
+      print*, "Input var = ", trim(names_inputs(iBMI))
+    end do
+
+    status = m%get_output_var_names(names_outputs)
+    do iBMI = 1, n_outputs
+      print*, "Output var = ", trim(names_outputs(iBMI))
+    end do
+    
+    ! Sum input and outputs to get total vars
+    count = n_inputs + n_outputs
+    
+    ! Get other variable info
+    do j = 1, count
+      if(j <= n_inputs) then
+        status = m%get_var_type(trim(names_inputs(j)), var_type)
+        status = m%get_var_units(trim(names_inputs(j)), var_units)
+        status = m%get_var_itemsize(trim(names_inputs(j)), var_itemsize)
+        status = m%get_var_nbytes(trim(names_inputs(j)), var_nbytes)
+        print*, "The variable ", trim(names_inputs(j))
+      else
+        status = m%get_var_type(trim(names_outputs(j - n_inputs)), var_type)
+        status = m%get_var_units(trim(names_outputs(j - n_inputs)), var_units)
+        status = m%get_var_itemsize(trim(names_outputs(j - n_inputs)), var_itemsize)
+        status = m%get_var_nbytes(trim(names_outputs(j - n_inputs)), var_nbytes)
+        print*, "The variable ", trim(names_outputs(j - n_inputs))
+      end if
+      print*, "    has a type of ", var_type
+      print*, "    units of ", var_units
+      print*, "    a size of ", var_itemsize
+      print*, "    and total n bytes of ", var_nbytes
+    end do
+
+    
+  !---------------------------------------------------------------------
+  ! Get time information
+  !---------------------------------------------------------------------
+    status = m%get_start_time(bmi_time)
+    print*, "The start time is ", bmi_time
+
+    status = m%get_current_time(bmi_time)
+    print*, "The current time is ", bmi_time
+
+    status = m%get_end_time(bmi_time)
+    print*, "The end time is ", bmi_time
+
+    status = m%get_time_step(timestep)
+    status = m%get_time_units(ts_units)
+    print*, " The time step is ", timestep
+    print*, "with a unit of ", ts_units
+
+  !---------------------------------------------------------------------
+  ! Run some time steps with the update_until function
+  !---------------------------------------------------------------------
+    time_until = 3600.0
+    status = m%update_until(time_until)
+    
+  !---------------------------------------------------------------------
+  ! Run the rest of the time with update in a loop
+  !---------------------------------------------------------------------
+    ! get the current and end time for running the execution loop
+    status = m%get_current_time(current_time)
+    status = m%get_end_time(end_time)
+  
+    ! loop through while current time <= end time
+    print*, "Running..."
+    do while (current_time < end_time)
+      status = m%update()                       ! run the model one time step
+      status = m%get_current_time(current_time) ! update current_time
+    end do
+
+  !---------------------------------------------------------------------
+  ! Test the get/set_value functionality with BMI
+  !---------------------------------------------------------------------
+    allocate(var_value_get(1))
+    allocate(var_value_set(1))
+    var_value_set = 999.9999
+    
+    ! Loop through the input vars
+    do iBMI = 1, n_inputs
+      status = m%get_value(trim(names_inputs(iBMI)), var_value_get)
+      print*, trim(names_inputs(iBMI)), " from get_value = ", var_value_get
+      print*, "    our replacement value = ", var_value_set
+      status = m%set_value(trim(names_inputs(iBMI)), var_value_set)
+      status = m%get_value(trim(names_inputs(iBMI)), var_value_get)
+      print*, "    and the new value of ", trim(names_inputs(iBMI)), " = ", var_value_get
+    end do
+    
+    ! Loop through the output vars
+    do iBMI = 1, n_outputs
+      status = m%get_value(trim(names_outputs(iBMI)), var_value_get)
+      print*, trim(names_outputs(iBMI)), " from get_value = ", var_value_get
+      print*, "    our replacement value = ", var_value_set
+      status = m%set_value(trim(names_outputs(iBMI)), var_value_set)
+      status = m%get_value(trim(names_outputs(iBMI)), var_value_get)
+      print*, "    and the new value of ", trim(names_outputs(iBMI)), " = ", var_value_get
+    end do
+    
+  !---------------------------------------------------------------------
+  ! The following functions are not implemented/only return BMI_FAILURE
+  ! Change if your model implements them
+  !---------------------------------------------------------------------
+  
+    print*, "The unstructured grid functions will return BMI_FAILURE"
+    print*, "BMI functions that require ", trim(component_name), &
+            " to use pointer vars are not implemented"
+  
+  !---------------------------------------------------------------------
+  ! Test the get_value_ptr functionality with BMI
+  !---------------------------------------------------------------------
+    var_value_get_ptr => var_value_get
+    ! test the get value pointer  functions
+    ! Loop through the input vars
+    do iBMI = 1, n_inputs
+      status = m%get_value_ptr(trim(names_inputs(iBMI)), var_value_get_ptr)
+      if ( status .eq. BMI_FAILURE ) then
+        print*, trim(names_inputs(iBMI)), " from get_value_ptr returned BMI_FAILURE --- test passed" 
+      else
+        print*, trim(names_inputs(iBMI)), " from get_value_ptr returned ", status, " TEST FAILED!" 
+      end if
+    end do
+
+    ! Loop through the output vars
+    do iBMI = 1, n_outputs
+      status = m%get_value_ptr(trim(names_outputs(iBMI)), var_value_get_ptr)
+      if ( status .eq. BMI_FAILURE ) then
+        print*, trim(names_outputs(iBMI)), " from get_value_ptr returned BMI_FAILURE --- test passed" 
+      else
+        print*, trim(names_outputs(iBMI)), " from get_value_ptr returned ", status, " TEST FAILED!" 
+      end if
+    end do
+
+  !---------------------------------------------------------------------
+  ! Test the get_value_at_indices functionality with BMI
+  !---------------------------------------------------------------------
+    ! Loop through the input vars
+    do iBMI = 1, n_inputs
+      status = m%get_value_at_indices(trim(names_inputs(iBMI)), var_value_get, grid_indices)
+      if ( status .eq. BMI_FAILURE ) then
+        print*, trim(names_inputs(iBMI)), " from get_value_at_indices returned BMI_FAILURE --- test passed" 
+      else
+        print*, trim(names_inputs(iBMI)), " from get_value_at_indices returned ", status, " TEST FAILED!" 
+      end if
+      status = m%set_value_at_indices(trim(names_inputs(iBMI)), grid_indices, var_value_set)
+      if ( status .eq. BMI_FAILURE ) then
+        print*, trim(names_inputs(iBMI)), " from set_value_at_indices returned BMI_FAILURE --- test passed" 
+      else
+        print*, trim(names_inputs(iBMI)), " from set_value_at_indices returned ", status, " TEST FAILED!" 
+      end if
+    end do
+    
+    ! Loop through the output vars
+    do iBMI = 1, n_outputs
+      status = m%get_value_at_indices(trim(names_outputs(iBMI)), var_value_get, grid_indices)
+      if ( status .eq. BMI_FAILURE ) then
+        print*, trim(names_outputs(iBMI)), " from get_value_at_indices returned BMI_FAILURE --- test passed" 
+      else
+        print*, trim(names_outputs(iBMI)), " from get_value_at_indices returned ", status, " TEST FAILED!" 
+      end if
+      status = m%set_value_at_indices(trim(names_outputs(iBMI)), grid_indices, var_value_set)
+      if ( status .eq. BMI_FAILURE ) then
+        print*, trim(names_outputs(iBMI)), " from set_value_at_indices returned BMI_FAILURE --- test passed" 
+      else
+        print*, trim(names_outputs(iBMI)), " from set_value_at_indices returned ", status, " TEST FAILED!" 
+      end if
+    end do
+
+    nullify( var_value_get_ptr )
+    deallocate(var_value_get)
+    deallocate(var_value_set)
+
+  !---------------------------------------------------------------------
+  ! Test the grid info functionality with BMI
+  !---------------------------------------------------------------------
+
+    ! All vars currently have same spatial discretization
+    ! Modify to test all discretizations if > 1
+    
+    ! get_var_grid
+    iBMI = 1
+    status = m%get_var_grid(trim(names_outputs(iBMI)), grid_int)
+    print*, "The integer value for the ", trim(names_outputs(iBMI)), " grid is ", grid_int
+    
+    ! get_grid_type
+    status = m%get_grid_type(grid_int, grid_type)
+    print*, "The grid type for ", trim(names_outputs(iBMI)), " is ", trim(grid_type)
+    
+    ! get_grid_rank
+    status = m%get_grid_rank(grid_int, grid_rank)
+    print*, "The grid rank for ", trim(names_outputs(iBMI)), " is ", grid_rank
+    
+    ! get_grid_shape
+    ! only scalars implemented thus far
+    status = m%get_grid_shape(grid_int, grid_shape)
+    if(grid_shape(1) == -1) then
+      print*, "No grid shape for the grid type/rank"
+    end if
+    
+    ! get_grid_size
+    status = m%get_grid_size(grid_int, grid_size)
+    print*, "The grid size for ", trim(names_outputs(iBMI)), " is ", grid_size
+    
+    ! get_grid_spacing
+    ! only scalars implemented thus far
+    status = m%get_grid_spacing(grid_int, grid_spacing)
+    if(grid_spacing(1) == -1.d0) then
+      print*, "No grid spacing for the grid type/rank"
+    end if
+   
+    ! get_grid_origin
+    ! only scalars implemented thus far
+    status = m%get_grid_origin(grid_int, grid_origin)
+    if(grid_origin(1) == -1.d0) then
+      print*, "No grid origin for the grid type/rank"
+    end if
+   
+    ! get_grid_x/y/z
+    ! should return 0 for a 1 node "grid" because not currently spatially explicit
+    status = m%get_grid_x(grid_int, grid_x)
+    status = m%get_grid_y(grid_int, grid_y)
+    status = m%get_grid_z(grid_int, grid_z)
+    print*, "The X coord for grid ", grid_int, " is ", grid_x
+    print*, "The Y coord for grid ", grid_int, " is ", grid_y
+    print*, "The Z coord for grid ", grid_int, " is ", grid_z
+    
+!---------------------------------------------------------------------
+  ! Finalize with BMI
+  !---------------------------------------------------------------------
+      print*, "Finalizing..."
+      status = m%finalize()
+      print*, "Model is finalized!"
+
+!  !---------------------------------------------------------------------
+!  ! End test
+!  !---------------------------------------------------------------------
+    print*, "All done testing!"
+
+end program


### PR DESCRIPTION
TYPE: Feature enhancements and bug fixes

KEYWORDS: Unit test, BMI 2.0, get_value_at_indices, get_value_ptr, runtime warnings and errors, the check=all compiler option

SOURCE: Zhengtao Cui, NOAA NWS OWP

DESCRIPTION OF CHANGES:

1) Implemented these get_value_at_indices and get_value_ptr to return BMI_FAILURE to be compliance with BMI 2.0 standards.
get_value_at_indices_int
get_value_at_indices_float
get_value_at_indices_double
set_value_at_indices_int
set_value_at_indices_float
set_value_at_indices_double

get_value_ptr_int

get_value_ptr_float

get_value_ptr_double

2) Added the unit test code. The unit code was created based on the unit test code in https://github.com/NOAA-OWP/noah-owp-modular/

3) Fixed the warnings and errors at runtime when it is compiled with the -fcheck=all option

At line 150 of file ..//src/share//runSnow17.f90
Fortran runtime warning: An array temporary was created
At line 152 of file ..//src/share//runSnow17.f90
Fortran runtime warning: An array temporary was created
 Finalizing...
At line 195 of file ..//src/share//runSnow17.f90
Fortran runtime error: Index '4' of dimension 1 of array 'model' above upper bound of 3


ISSUE: There are compiling warnings about unused dummy variables.

TESTS CONDUCTED: Tested with the unit test code. All tests passed.

NOTES: Tested only with the gfortran compiler on Hera. Need to be tested with an Intel compiler.


