### PR TITLE
Ngen instruct

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,6 @@ ex1/
 
 # local Makefile versions
 *.local
+
+# CMake Build Dir (ngen)
+cmake_build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,95 @@
+cmake_minimum_required(VERSION 3.12)
+enable_language( Fortran )
+add_subdirectory(../iso_c_fortran_bmi ${CMAKE_BINARY_DIR}/iso_c_bmi)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../../cmake/")
+# Uncomment this and rebuild artifacts to enable debugging
+#set(CMAKE_BUILD_TYPE Debug)
+add_compile_options(
+  "-Wall"
+  "$<$<CONFIG:DEBUG>:-g;-fbacktrace;-fbounds-check>"
+)
+project(snow17 VERSION 1.0.0 DESCRIPTION "External BMI Models Shared Libraries")
+
+set( CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/fortran)
+
+#### Add variables for individual libraries that are used within the *.pc.in files
+# Snow17
+set(SNOW17_LIB_NAME_CMAKE snow17bmi)
+set(SNOW17_LIB_DESC_CMAKE "External Snow17 Shared Library")
+
+# Make sure these are compiled with this directive
+add_compile_definitions(BMI_ACTIVE NGEN_FORCING_ACTIVE NGEN_OUTPUT_ACTIVE NGEN_ACTIVE)
+
+#Use ../../../FindNetCDF.cmake, which looks for config package, pkgconfig, and standard file locations
+#in that order
+###### 
+# Updates to snow17 allow a build of the bmi module that does not require netcdf
+# The NGEN_OUTPUT_ACTIVE compiler directive disables all netcdf related code, hence no need
+# to link the netcdf library. If at some point this becomes required, the following section
+# can be uncommented to provide mechanics to look for and/or define netcdf requirements.
+# Also, the target link library line will need uncommented below.
+######
+###### NETCDF ######
+# find_package (NetCDF COMPONENTS F90)
+# set(netCDF_INCLUDE_DIR ${NetCDF_INCLUDE_DIRS} CACHE PATH "NetCDF Include Directory" )
+# set(netCDF_C_LIB ${NetCDF_LIBRARIES} CACHE PATH 
+# "The path to the C shared object library file, libnetcdf.so or the library name if it can be found by the linker, i.e. netcdf" )
+# if(NetCDF_FOUND)
+#   #This provides a little diagnostic output, but most importantly, gives cache varabiles
+#   #for each piece of the netcdf puzzle that a user might need to directly override
+#   #if netcdf isn't configured correctly or cannot be found using the known methods.
+#   message("Found netCDF package")
+#   message("NetCDF inc: " ${NetCDF_INCLUDE_DIR})
+#   message("NetCDF lib: " ${NetCDF_LIBRARIES})
+# else()
+#   message(SEND_ERROR "Could not find NetCDF, install the depdency or\n 1) Set the NetCDF_DIR to a source build\n 2) set the netCDF* cache variables as appropriate")
+# endif()
+# # Ensure we can find the netcdf.mod file, leave a cache var that can be set if we can't
+# find_path(_netCDF_MOD_PATH "netcdf.mod" ${netCDF_INCLUDE_DIR} REQUIRED NO_CACHE)
+# set(netCDF_MOD_PATH ${_netCDF_MOD_PATH} CACHE PATH "Directory containing the netcdf.mod fortran module")
+
+# # For some reason the netcdf config.cmake doesn't set the netcdff lib correctly in
+# # ${netCDF_Libararies}, so it only links the C lib (netcdf) and not the fortran lib (netcdff)
+# # So find that library explicitly and make sure we link with it.
+# # also, the FindNetCDF.cmake doesn't seem to do it correctly either.
+
+# find_library(_netCDF_FORTRAN_LIB netcdff REQUIRED  NO_CACHE)
+# set(netCDF_FORTRAN_LIB ${_netCDF_FORTRAN_LIB} CACHE PATH 
+# "The path to the C shared object library file, libnetcdff.so or the library name if it can be found by the linker, i.e. netcdff")
+##### END NETCDF #####
+
+set(MODEL_SOURCE_DIR src/)
+set(BMI_SOURCE_DIR src/bmi/)
+
+file(GLOB BMI_SOURCE ${BMI_SOURCE_DIR}*.f90)
+file( GLOB MODEL_SOURCES ${MODEL_SOURCE_DIR}/snow19/*.f ${MODEL_SOURCE_DIR}/driver/*.f90 ${MODEL_SOURCE_DIR}/share/*.f90)
+
+if(WIN32)
+    add_library(snow17bmi ${BMI_SOURCE} )
+else()
+    add_library(snow17bmi SHARED ${BMI_SOURCE} ${MODEL_SOURCES} )
+endif()
+
+#target_include_directories(snow17bmi PUBLIC ${netCDF_INCLUDE_DIR} ${netCDF_MOD_PATH})    # netcdf not needed for this code
+target_include_directories( snow17bmi PUBLIC )    
+
+#We know we are building this for NGEN support, so define the preprocessor directive in the compile options
+#Not sure why the global 
+target_compile_options(snow17bmi PUBLIC -cpp -ffree-line-length-none)
+
+##### NETCDF #####
+#target_link_libraries( snow17bmi iso_c_bmi ${netCDF_C_LIB} ${netCDF_FORTRAN_LIB})
+##### END NETCDF #####
+target_link_libraries( snow17bmi PUBLIC iso_c_bmi )
+set_target_properties(snow17bmi PROPERTIES VERSION ${PROJECT_VERSION})
+
+include(GNUInstallDirs)
+
+install(TARGETS snow17bmi
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+configure_file(snow17bmi.pc.in snow17bmi.pc @ONLY)
+
+install(FILES ${CMAKE_BINARY_DIR}/snow17bmi.pc DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/pkgconfig)

--- a/NGEN_EXAMPLE.md
+++ b/NGEN_EXAMPLE.md
@@ -24,7 +24,7 @@ Then, clone, update and build the following modules,
     ```
   - #### Snow17
     ```
-    git clone https://github.com/NOAA-OWP/snow17.git ./extern
+    git clone https://github.com/NOAA-OWP/snow17.git ./extern/snow17
     cmake -B extern/snow17/cmake_build -S extern/snow17
     cmake --build extern/snow17/cmake_build --target all
     ``` 
@@ -52,7 +52,7 @@ Then, clone, update and build the following modules,
  ### Run 
 Pre-process step for configuration and data pathing
  ```
-  tar -xzvf extern/snow17/test_cases/ex1.tgz extern/snow17/test_cases/
+  tar -xzvf extern/snow17/test_cases/ex1.tgz -C extern/snow17/test_cases/
   cp extern/snow17/configs/example_bmi_multi_realization_config_w_snow17.json data/
   cp extern/snow17/configs/snow17-init-cat-27.namelist.input data/bmi/fortran/
   ```

--- a/NGEN_EXAMPLE.md
+++ b/NGEN_EXAMPLE.md
@@ -1,20 +1,23 @@
 # Running Snow17 in NextGen with Sample Data
 
-See general [instructions](https://github.com/NOAA-OWP/ngen/wiki/NGen-Tutorial#running-cfe) for building models in the ngen framework. 
+See general [instructions](https://github.com/NOAA-OWP/ngen/wiki/NGen-Tutorial) for building and running models in the NextGen framework. This document outlines a valid workflow for coupling [CFE](https://github.com/NOAA-OWP/cfe), [PET](https://github.com/NOAA-OWP/evapotranspiration), and [Snow17](https://github.com/NOAA-OWP/snow17) in ngen as a single catchment model execution.  Forcing data is provided by the framework.   
 
 ### Build
+First, clone `ngen` and update it's submodules.
 ```
 git clone https://github.com/noaa-owp/ngen && cd ngen
 git submodule update --init --recursive
 ```
-  
+Then, clone, update and build the following modules,  
   - #### CFE
     ```
     git submodule update --remote extern/cfe/cfe 
     cmake -B extern/cfe/cmake_build -S extern/cfe/cfe/ -DNGEN=ON
     make -C extern/cfe/cmake_build
     ```  
-  - #### fortran bmi
+  - #### Fortran BMI
+    [This](https://github.com/NOAA-OWP/ngen/tree/master/extern/iso_c_fortran_bmi) light-weight library allows for C/Fortran interoperability for BMI functions.
+
     ```
     cmake -B extern/iso_c_fortran_bmi/cmake_build -S extern/iso_c_fortran_bmi
     make -C extern/iso_c_fortran_bmi/cmake_build
@@ -30,7 +33,9 @@ git submodule update --init --recursive
     cmake -B extern/evapotranspiration/cmake_build -S extern/evapotranspiration/evapotranspiration/
     make -C extern/evapotranspiration/cmake_build/
     ```
-  - #### Build [SLoTH](https://github.com/NOAA-OWP/SLoTH) using the following instructions. SLoTH bmi provides dummy values for bmi input variables that are not used in the realization.
+  - #### SLoTH
+    [SLoTH](https://github.com/NOAA-OWP/SLoTH) BMI provides dummy values for bmi input variables that are not used in the realization.
+
     ```
     cd extern/sloth/ && git checkout latest 
     git submodule update --init --recursive
@@ -39,20 +44,20 @@ git submodule update --init --recursive
     make -C extern/sloth/cmake_build
     ```
   - #### NGEN
-  ```
-  cmake -B cmake_build -S . -DBMI_C_LIB_ACTIVE=ON -DBMI_FORTRAN_ACTIVE=ON
-  make -j4 -C cmake_build
-  ```
+    ```
+    cmake -B cmake_build -S . -DBMI_C_LIB_ACTIVE=ON -DBMI_FORTRAN_ACTIVE=ON
+    make -j4 -C cmake_build
+    ```
   
  ### Run 
 Pre-process step for configuration and data pathing
  ```
   tar -xzvf extern/snow17/test_cases/ex1.tgz extern/snow17/test_cases/
-  cp extern/snow17/configs/example_bmi_multi_realization_config_w_snow17.json data
-  cp extern/snow17/configs/snow17-init-cat-27.namelist.input data/bmi/fortran/snow17-init-cat-27.namelist.input
+  cp extern/snow17/configs/example_bmi_multi_realization_config_w_snow17.json data/
+  cp extern/snow17/configs/snow17-init-cat-27.namelist.input data/bmi/fortran/
   ```
 Integrated models (SLoTH+PET+Snow17+CFE) example 
  ```
 ./cmake_build/ngen data/catchment_data.geojson cat-27 data/nexus_data.geojson nex-26 data/example_bmi_multi_realization_config_w_snow17.json
  ```
-  
+See output files `cat-27.csv` and `nex-26_output.csv` for model results. 

--- a/NGEN_EXAMPLE.md
+++ b/NGEN_EXAMPLE.md
@@ -1,0 +1,58 @@
+# Running Snow17 in NextGen with Sample Data
+
+See general [instructions](https://github.com/NOAA-OWP/ngen/wiki/NGen-Tutorial#running-cfe) for building models in the ngen framework. 
+
+### Build
+```
+git clone https://github.com/noaa-owp/ngen && cd ngen
+git submodule update --init --recursive
+```
+  
+  - #### CFE
+    ```
+    git submodule update --remote extern/cfe/cfe 
+    cmake -B extern/cfe/cmake_build -S extern/cfe/cfe/ -DNGEN=ON
+    make -C extern/cfe/cmake_build
+    ```  
+  - #### fortran bmi
+    ```
+    cmake -B extern/iso_c_fortran_bmi/cmake_build -S extern/iso_c_fortran_bmi
+    make -C extern/iso_c_fortran_bmi/cmake_build
+    ```
+  - #### Snow17
+    ```
+    git clone https://github.com/NOAA-OWP/snow17.git ./extern
+    cmake -B extern/snow17/cmake_build -S extern/snow17
+    cmake --build extern/snow17/cmake_build --target all
+    ``` 
+  - #### PET
+    ```
+    cmake -B extern/evapotranspiration/cmake_build -S extern/evapotranspiration/evapotranspiration/
+    make -C extern/evapotranspiration/cmake_build/
+    ```
+  - #### Build [SLoTH](https://github.com/NOAA-OWP/SLoTH) using the following instructions. SLoTH bmi provides dummy values for bmi input variables that are not used in the realization.
+    ```
+    cd extern/sloth/ && git checkout latest 
+    git submodule update --init --recursive
+    cd ../..
+    cmake -B extern/sloth/cmake_build -S extern/sloth/
+    make -C extern/sloth/cmake_build
+    ```
+  - #### NGEN
+  ```
+  cmake -B cmake_build -S . -DBMI_C_LIB_ACTIVE=ON -DBMI_FORTRAN_ACTIVE=ON
+  make -j4 -C cmake_build
+  ```
+  
+ ### Run 
+Pre-process step for configuration and data pathing
+ ```
+  tar -xzvf extern/snow17/test_cases/ex1.tgz extern/snow17/test_cases/
+  cp extern/snow17/configs/example_bmi_multi_realization_config_w_snow17.json data
+  cp extern/snow17/configs/snow17-init-cat-27.namelist.input data/bmi/fortran/snow17-init-cat-27.namelist.input
+  ```
+Integrated models (SLoTH+PET+Snow17+CFE) example 
+ ```
+./cmake_build/ngen data/catchment_data.geojson cat-27 data/nexus_data.geojson nex-26 data/example_bmi_multi_realization_config_w_snow17.json
+ ```
+  

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ There are no current dependencies except for a Fortran-compatible compiler (e.g.
 
 To build and run Snow-17 with example data, check out the [INSTALL](INSTALL.md) document.
 
-## Configuration
+## Snow17 & NextGen
 
-TBA:  If the software is configurable, describe it in detail, either here or in other documentation to which you link.
+See [NGEN_EXAMPLE](NGEN_EXAMPLE.md) for guidance on building and running Snow17 in a model coupling framework.
 
 ## How to test the software
 

--- a/configs/example_bmi_multi_realization_config_w_snow17.json
+++ b/configs/example_bmi_multi_realization_config_w_snow17.json
@@ -1,0 +1,103 @@
+{
+    "global": {
+        "formulations": [
+            {
+                "name": "bmi_multi",
+                "params": {
+                    "model_type_name": "bmi_multi_snow17_cfe",
+                    "forcing_file": "",
+                    "init_config": "",
+                    "allow_exceed_end_time": true,
+                    "main_output_variable": "Q_OUT",
+                    "modules": [
+			{
+			    "name": "bmi_c++",
+			    "params": {
+                                "model_type_name": "bmi_c++_sloth",
+                                "library_file": "./extern/sloth/cmake_build/libslothmodel.so",
+                                "init_config": "/dev/null",
+                                "allow_exceed_end_time": true,
+                                "main_output_variable": "z",
+                                "uses_forcing_file": false,
+                                "model_params": {
+				    "sloth_ice_fraction_schaake(1,double,m,node)": 0.0,
+				    "sloth_ice_fraction_xinan(1,double,1,node)": 0.0,
+				    "sloth_smp(1,double,1,node)": 0.0
+                                }
+			    }
+                        },
+                        {
+                            "name": "bmi_fortran",
+                            "params": {
+                                "model_type_name": "bmi_fortran_snow17",
+                                "library_file": "./extern/snow17/cmake_build/libsnow17bmi",
+                                "forcing_file": "",
+                                "init_config": "./data/bmi/fortran/snow17-init-{{id}}.namelist.input",
+                                "allow_exceed_end_time": true,
+                                "main_output_variable": "raim",
+                                "variables_names_map": {
+                                    "precip": "atmosphere_water__liquid_equivalent_precipitation_rate",
+                                    "tair": "land_surface_air__temperature"
+                                },
+                                "uses_forcing_file": false
+                            }
+                        },
+                        {
+                            "name": "bmi_c",
+                            "params": {
+                                "model_type_name": "bmi_c_pet",
+                                "library_file": "./extern/evapotranspiration/cmake_build/libpetbmi",
+                                "forcing_file": "",
+                                "init_config": "./data/bmi/c/pet/{{id}}_bmi_config.ini",
+                                "allow_exceed_end_time": true,
+                                "main_output_variable": "water_potential_evaporation_flux",
+                                "registration_function": "register_bmi_pet",
+                                "variables_names_map": {
+                                    "water_potential_evaporation_flux": "potential_evapotranspiration"
+                                },
+                                "uses_forcing_file": false
+                            }
+                        },                        
+                        {
+                            "name": "bmi_c",
+                            "params": {
+                                "model_type_name": "bmi_c_cfe",
+                                "library_file": "./extern/cfe/cmake_build/libcfebmi",
+                                "forcing_file": "",
+                                "init_config": "./data/bmi/c/cfe/{{id}}_bmi_config.ini",
+                                "allow_exceed_end_time": true,
+                                "main_output_variable": "Q_OUT",
+                                "registration_function": "register_bmi_cfe",
+                                "variables_names_map": {
+                                    "water_potential_evaporation_flux": "potential_evapotranspiration",
+                                    "atmosphere_air_water~vapor__relative_saturation": "SPFH_2maboveground",
+                                    "land_surface_air__temperature": "TMP_2maboveground",
+                                    "land_surface_wind__x_component_of_velocity": "UGRD_10maboveground",
+                                    "land_surface_wind__y_component_of_velocity": "VGRD_10maboveground",
+                                    "land_surface_radiation~incoming~longwave__energy_flux": "DLWRF_surface",
+                                    "land_surface_radiation~incoming~shortwave__energy_flux": "DSWRF_surface",
+                                    "land_surface_air__pressure": "PRES_surface",
+				    "ice_fraction_schaake" : "sloth_ice_fraction_schaake",
+				    "ice_fraction_xinan" : "sloth_ice_fraction_xinan",
+				    "soil_moisture_profile" : "sloth_smp"
+                                },
+                                "uses_forcing_file": false
+                            }
+                        }
+                    ],
+                    "uses_forcing_file": false
+                }
+            }
+        ],
+        "forcing": {
+            "file_pattern": ".*{{id}}.*.csv",
+            "path": "./data/forcing/",
+            "provider": "CsvPerFeature"
+        }
+    },
+    "time": {
+        "start_time": "2015-12-01 00:00:00",
+        "end_time": "2015-12-30 23:00:00",
+        "output_interval": 3600
+    }
+}

--- a/configs/snow17-init-cat-27.namelist.input
+++ b/configs/snow17-init-cat-27.namelist.input
@@ -1,0 +1,26 @@
+&SNOW17_CONTROL
+! === run control file for snow17bmi v. 1.x ===
+
+! -- basin config and path information
+main_id             = "cat-27"     ! basin label or gage id 
+n_hrus              = 1            ! number of sub-areas in model
+forcing_root        = "extern/snow17/test_cases/hf_catchment/input/forcing/forcing.snow17bmi."
+output_root         = "data/output/output.snow17bmi."
+snow17_param_file   = "extern/snow17/test_cases/ex1/input/params/snow17_params.HHWM8.txt"
+output_hrus         = 1            ! output HRU results? (1=yes; 0=no)
+
+! -- run period information
+start_datehr        = 2015120101   ! start date time, backward looking (check)
+end_datehr          = 2015123023   ! end date time
+model_timestep      = 3600        ! in seconds (86400 seconds = 1 day)
+
+! -- state start/write flags and files
+warm_start_run      = 0	 ! is this run started from a state file?  (no=0 yes=1)
+write_states        = 0  ! write restart/state files for 'warm_start' runs (no=0 yes=1)
+
+! -- filenames only needed if warm_start_run = 1
+snow_state_in_root  = "data/state/snow17_states."  ! input state filename root
+
+! -- filenames only needed if write_states = 1
+snow_state_out_root = "data/state/snow17_states."  ! output states filename root
+/

--- a/snow17bmi.pc.in
+++ b/snow17bmi.pc.in
@@ -1,0 +1,12 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+
+Name: @SNOW17_LIB_NAME_CMAKE@
+Description: @SNOW17_DESC_CMAKE@
+Version: @PROJECT_VERSION@
+
+Requires:
+Libs: -L${libdir} -lmylib
+Cflags: -I${includedir}


### PR DESCRIPTION
Includes all information (files and instructions) for building and running snow17 in the framework over single catchment; coupled with CFE & PET. 

Replaces `NOAA-OWP/ngen` open PR [here](https://github.com/NOAA-OWP/ngen/pull/462).

## Additions

- Necessary build, data & config files for `ngen` runs.

## Testing
On a MacOS Monterey M2,

1. Standalone as outline in `INSTALL.md`
2. In `ngen`, coupled with CFE & PET for cat-27.  See `NGEN_EXAMPLE.md` 

## Todos

-  Confirm model inputs are correct for cat-27

