### PR TITLE
chore: fix CFE example ngen realization name mapping (see CFE #94}

### DIFF
--- a/configs/example_bmi_multi_realization_config_w_snow17.json
+++ b/configs/example_bmi_multi_realization_config_w_snow17.json
@@ -78,7 +78,7 @@
                                     "land_surface_radiation~incoming~shortwave__energy_flux": "DSWRF_surface",
                                     "land_surface_air__pressure": "PRES_surface",
 				    "ice_fraction_schaake" : "sloth_ice_fraction_schaake",
-				    "ice_fraction_xinan" : "sloth_ice_fraction_xinan",
+				    "ice_fraction_xinanjiang" : "sloth_ice_fraction_xinan",
 				    "soil_moisture_profile" : "sloth_smp"
                                 },
                                 "uses_forcing_file": false


### PR DESCRIPTION
Change required b.c. https://github.com/NOAA-OWP/cfe/pull/94.

@drakest123 found this issue when running trying to run the [example ngen test case](https://github.com/NOAA-OWP/snow17/blob/c0a9c4bb4ee0d1917d05415eb9e012a079525c41/NGEN_EXAMPLE.md) (thanks, @drakest123!)