### PR TITLE
Bug fixes

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -3,7 +3,7 @@
 1. Clone the online GitHub repository either from the main git repo source (https://github.com/NOAA-OWP/snow17.git) or your fork of it -- e.g., `git clone https://github.com/NOAA-OWP/snow17.git`
 2. Change directory to the build directory: `cd snow17/build/`
 3. Copy `Makefile` to `Makefile.local` (`cp Makefile Makefile.local`) and edit the local version to update the compiler and paths if necessary to match the resources on your system.
-4. Run `make -f MakefileLocal` to compile the program and generate the executable, which will be found in `snow17/bin/`
+4. Run `make -f Makefile.local` to compile the program and generate the executable, which will be found in `snow17/bin/`
 5. There is a test case in the `snow17/test_cases/` directory.  To run it, first cd to the directory (`cd ../test_cases/`) and unpack the example:  `tar -xzvf ex1.tgz`.
 6. `cd ex1/run/` to get to the run directory and then execute the shell script (`./runSnow17.csh`) or type `../../../bin/snow17.exe namelist.bmi.HHWM8` into your command line
 7. Check the example in the output folder (`cd ../output/`)
@@ -12,8 +12,8 @@ TL;DR:
 ```
 git clone https://github.com/NOAA-OWP/snow17.git
 cd snow17/build/
-cp Makefile MakefileLocal # edit to match your compiler and system resources
-make -f MakefileLocal
+cp Makefile Makefile.local # edit to match your compiler and system resources
+make -f Makefile.local
 cd ../test_cases/
 tar -xzvf ex1.tgz
 cd ex1/run/

--- a/src/share/forcingType.f90
+++ b/src/share/forcingType.f90
@@ -28,7 +28,7 @@ contains
     use defNamelist
     implicit none
 
-    class(forcing_type), intent(out) :: this
+    class(forcing_type), intent(inout) :: this
     type(namelist_type), intent(in)  :: namelist
 
     ! -- variable allocations (time dim not needed since forcings are one-rec scalars)

--- a/src/share/ioModule.f90
+++ b/src/share/ioModule.f90
@@ -172,6 +172,7 @@ contains
 
     ! --- code ------------------------------------------------------------------
     print*, 'Initializing forcing files'
+    ios = 0
     found_start = 0
     do nh=1, runinfo%n_hrus
 

--- a/src/share/modelVarType.f90
+++ b/src/share/modelVarType.f90
@@ -33,7 +33,7 @@ module modelVarType
     implicit none
 
     ! define variables
-    class(modelvar_type), intent(out) :: this
+    class(modelvar_type), intent(inout) :: this
     type(namelist_type), intent(in)   :: namelist
     
     ! -- variable allocations (time dim not needed since forcings are one-rec scalars)

--- a/src/snow19/updt19.f
+++ b/src/snow19/updt19.f
@@ -13,6 +13,7 @@ C           ERIC ANDERSON - HRL - DECEMBER 1982
 
 CVK        MODIFIED 4/00 BY V. KOREN: TWO NEW STATES ADDED
 C.......................................
+      REAL LIQW
       DIMENSION ADC(11)
 C
 C     COMMON BLOCKS


### PR DESCRIPTION
Bug fixes to compile and run Snow-17 on Mac M3 Max chip and Fortran Intel compiler.

### Bug Fix 1:
When compiling Snow-17 with an M3 Max CPU I get the following error:
`% make -f Makefile.local gfortran -O3 -fdefault-real-8 -fno-align-commons -ffree-line-length-none -cpp -fcheck=all -march=native -c  ..//src/snow19//zero19.f  ..//src/snow19//rout19.f  ..//src/snow19//aesc19.f  ..//src/snow19//melt19.f  ..//src/snow19//SNEW.f  ..//src/snow19//SNOWT.f  ..//src/snow19//SNOWPACK.f  ..//src/snow19//adjc19.f  ..//src/snow19//aeco19.f  ..//src/snow19//updt19.f  ..//src/snow19//SNDEPTH.f  ..//src/snow19//PACK19.f  ..//src/snow19//exsnow19.f -I/opt/homebrew/include gfortran -O3 -fdefault-real-8 -fno-align-commons -ffree-line-length-none -cpp -fcheck=all -c  ..//src/share//nrtype.f90  ..//src/share//constants.f90  ..//src/share//namelistModule.f90  ..//src/share//parametersType.f90  ..//src/share//forcingType.f90  ..//src/share//dateTimeUtilsModule.f90  ..//src/share//runInfoType.f90  ..//src/share//modelVarType.f90  ..//src/share//ioModule.f90  ..//src/share//runSnow17.f90  ..//src/bmi//bmi.f90  ..//src/bmi//bmi_snow17.f90  ..//src/driver//driver_bmi.f90 -I/opt/homebrew/include gfortran -fPIC -I/opt/homebrew/include -L/opt/homebrew/lib  -o ..//bin//snow17.exe *.o  Undefined symbols for architecture arm64: "_is_recursive.12.0", referenced from: ___forcingtype_MOD_initforcing in forcingType.o ___forcingtype_MOD_initforcing in forcingType.o ___forcingtype_MOD_initforcing in forcingType.o "_is_recursive.14.0", referenced from: ___modelvartype_MOD_initmodelvar in modelVarType.o ___modelvartype_MOD_initmodelvar in modelVarType.o ___modelvartype_MOD_initmodelvar in modelVarType.o ld: symbol(s) not found for architecture arm64 collect2: error: ld returned 1 exit status make: *** [link] Error 1`

**Resolution:**

```
In share/forcingType.f90 change:
class(forcing_type), intent(out) :: this
to:
class(forcing_type), intent(inout) :: this
In share/modelVarType.f90 change:
class(modelvar_type), intent(out) :: this
to
class(modelvar_type), intent(inout) :: this
```

### Bug Fix 2
Building Snow-17 (standalone) on a PC in Visual Studio using the Intel Fortran compiler produces an error in updt19.f at line 50:
`Error #6633: The type of the actual argument differs from the type of dummy argument. [LIQW]`

**Resolution:**

The error is caused because LIQW is implicitly INTEGER type. This error was fixed by add at line 25 of updt19.f:
`REAL LIQW`

**Bug Fix 3**
When building Snow-17 (standalone) on a PC in Visual Studio using the Intel Fortran compiler, the program fails to read forcing data files and crashes. In file ioModule.f90, subroutine init_forcing_files(), the integer ios is not initialized and acquires an unrestricted value with this compiler.

**Resolution:**

Add at line 175: `ios = 0`


### Target Environment support

- [X] Windows
- [X] Mac OSX
- [ ] Linux
- [ ] Browser


