### PR TITLE
Correcting skipped assignments in the forcing module when snow17 is run in nextgen, one of which led to melt errors.  

### DIFF
--- a/src/share/ioModule.f90
+++ b/src/share/ioModule.f90
@@ -284,15 +284,6 @@ contains
         print*, 'ERROR: forcing datehr: ',forcing_datehr, ' does not match curr_datehr of run :', runinfo%curr_datehr
         STOP
       end if 
-
-      ! update other forcing fields (derived)
-      ! NOTE: this is written now for a single temperature input (tair), but the standard for running snow17+sac is tmin/tmax
-      !       we could return to the standard though a namelist option if needed
-      forcing%precip_scf(nh) = forcing%precip(nh) * parameters%scf(nh)   ! scale input precip by snow correction factor
-                                                                         ! (note: this is for output; model input 
-                                                                         ! precip is scaled in pack19()
-
-      call sfc_pressure(parameters%elev(nh), forcing%pa(nh))             ! fill in the surface pressure field                   
                                                         
     end do  ! end loop across snowbands (hrus)
     
@@ -383,7 +374,7 @@ contains
       
         ! Write 1-line header
         write(runinfo%state_fileunits(nh),'(A)') &
-         'datehr tprev cs1 cs2 cs3 cs4 cs5 cs6 cs7 cs8cs9 cs10 cs11 cs12 cs13 cs14 cs15 cs16 cs17 cs18 cs19'
+         'datehr tprev cs1 cs2 cs3 cs4 cs5 cs6 cs7 cs8 cs9 cs10 cs11 cs12 cs13 cs14 cs15 cs16 cs17 cs18 cs19'
   
       end do  ! end loop over sub-units
     end if   

--- a/src/share/runSnow17.f90
+++ b/src/share/runSnow17.f90
@@ -151,6 +151,10 @@ contains
 
         prcp_mm = forcing%precip(nh)*runinfo%dt   ! convert prcp input to a depth per timestep (mm)
 
+        call sfc_pressure(parameters%elev(nh), forcing%pa(nh))  ! fill in the surface pressure field (in mb)
+                                                                ! uses elev. based constant PA (Anderson, 2006)
+                                                                ! (alternative: input PA as a dynamic forcing)
+
         call exsnow19(int(runinfo%dt), int(runinfo%dt/3600), runinfo%curr_dy, runinfo%curr_mo, runinfo%curr_yr, &
     	  ! SNOW17 INPUT AND OUTPUT VARIABLES
           prcp_mm, forcing%tair(nh), modelvar%raim(nh), modelvar%sneqv(nh), modelvar%snow(nh), modelvar%snowh(nh), &
@@ -165,6 +169,9 @@ contains
 
         ! convert raim output to a rate (mm/s)
         modelvar%raim(nh) = modelvar%raim(nh) / runinfo%dt
+
+        ! scale precip by correction factor (nb: for output; model input precip is scaled in pack19()
+        forcing%precip_scf(nh) = forcing%precip(nh) * parameters%scf(nh) 
         
         ! update basin-averaged variables
         forcing%tair_comb        = forcing%tair_comb + forcing%tair(nh) * parameters%hru_area(nh)


### PR DESCRIPTION
Moved two assignments from the read_areal_forcing() routing in ioModule into the solve_snow() routing in runSnow17 module.  One assigned surface pressure forcing, and the other stored the scaled pcp for output.  Without this change, pressure (PA) is unassigned when the model is run in nextgen, leading to melt errors.

## Testing
The updated code was compiled and run for the test case (ex1), yielding identical outputs to the original code; the compiler was gfortran and OS was linux (NCAR derecho login node). 

## Notes
This bug was diagnosed and fixed by Josh Sturtevant and Andy Wood (CO School of Mines). 