### PR TITLE
fix: Fix SAVE gotcha with read_snow17_parameters

### DIFF
--- a/src/share/ioModule.f90
+++ b/src/share/ioModule.f90
@@ -24,10 +24,13 @@ contains
     ! local variables
     character(len=400)      :: readline
     character(len=50)		:: param
-    integer    	            :: ios=0   ! specify i4b with nrtype?
+    integer    	            :: ios   ! specify i4b with nrtype?
     integer                 :: pos
     integer                 :: n_params_read, nh  ! counters
   
+    !Use assignment instead of declaration+initialization to avoid SAVE attribute gotcha
+    ios = 0
+
     ! open parameter file
     open(unit=51,file=trim(param_file_name),status='old')
   


### PR DESCRIPTION
Fixing bug in `read_snow17_parameters` subroutine.  The overall result of this bug is that it is not currently possible to use this with ngen whenever more than one catchment formulation uses this as a BMI module.  

## Bug Description
For the `read_snow17_parameters` subroutine, the local `ios` variable is used by each `read` to get the next line of the given parameter file.  A test of `ios` is used to determine when all lines of the parameter file have been read.

The problem is that the value of `ios` is being initialized as part of its declaration.  As noted [here](https://fortran-lang.org/learn/quickstart/variables/#declaring-variables) and elsewhere, initializing at declaration implies the `SAVE` attribute is applied to the variable.   The effect is that `ios` retains its value between calls. 

Thus, `ios` is only properly set the first time the subroutine is run.  In the second run, the test of whether the file has been completely read yields a false positive immediately, before any lines and parameter values have been read.  That, in turn, leads to an error condition and a `stop`.  

## Changes

The declaration of `ios` is changed to not include initialization, and then a subsequent assignment statement is used to properly initialize its expected value for the start of `read_snow17_parameters`.

## Testing

Local testing has been performed to ensure the `read_snow17_parameters` now completes without stopping execution.
