### PR TITLE
Add calibratable parameters to the bmi interface

### DIFF
--- a/src/bmi/bmi_snow17.f90
+++ b/src/bmi/bmi_snow17.f90
@@ -290,6 +290,10 @@ contains
     case('scf', 'mfmax', 'mfmin', 'uadj', 'si')       ! parameters
        grid = 0
        bmi_status = BMI_SUCCESS
+    case('adc1', 'adc2', 'adc3', 'adc4', 'adc5', 'adc6', &
+         'adc7', 'adc8', 'adc9', 'adc10', 'adc11')  ! adc parameters
+       grid = 0
+       bmi_status = BMI_SUCCESS
     case default
        grid = -1
        bmi_status = BMI_FAILURE
@@ -564,6 +568,10 @@ contains
     case('scf', 'mfmax', 'mfmin', 'uadj', 'si')       ! parameters
        type = "real"
        bmi_status = BMI_SUCCESS
+    case('adc1', 'adc2', 'adc3', 'adc4', 'adc5', 'adc6', &
+         'adc7', 'adc8', 'adc9', 'adc10', 'adc11')    ! adc parameters
+       type = "real"
+       bmi_status = BMI_SUCCESS
     case default
        type = "-"
        bmi_status = BMI_FAILURE
@@ -645,6 +653,39 @@ contains
        bmi_status = BMI_SUCCESS
     case("si")
        size = sizeof(this%model%parameters%si(1))
+       bmi_status = BMI_SUCCESS
+    case("adc1")
+       size = sizeof(this%model%parameters%adc(1,1))
+       bmi_status = BMI_SUCCESS
+    case("adc2")
+       size = sizeof(this%model%parameters%adc(2,1))
+       bmi_status = BMI_SUCCESS
+    case("adc3")
+       size = sizeof(this%model%parameters%adc(3,1))
+       bmi_status = BMI_SUCCESS
+    case("adc4")
+       size = sizeof(this%model%parameters%adc(4,1))
+       bmi_status = BMI_SUCCESS
+    case("adc5")
+       size = sizeof(this%model%parameters%adc(5,1))
+       bmi_status = BMI_SUCCESS
+    case("adc6")
+       size = sizeof(this%model%parameters%adc(6,1))
+       bmi_status = BMI_SUCCESS
+    case("adc7")
+       size = sizeof(this%model%parameters%adc(7,1))
+       bmi_status = BMI_SUCCESS
+    case("adc8")
+       size = sizeof(this%model%parameters%adc(8,1))
+       bmi_status = BMI_SUCCESS
+    case("adc9")
+       size = sizeof(this%model%parameters%adc(9,1))
+       bmi_status = BMI_SUCCESS
+    case("adc10")
+       size = sizeof(this%model%parameters%adc(10,1))
+       bmi_status = BMI_SUCCESS
+    case("adc11")
+       size = sizeof(this%model%parameters%adc(11,1))
        bmi_status = BMI_SUCCESS
     case default
        size = -1
@@ -922,6 +963,39 @@ contains
        bmi_status = BMI_SUCCESS
     case("si")
        this%model%parameters%si(:) = src(:)
+       bmi_status = BMI_SUCCESS
+    case("adc1")
+       this%model%parameters%adc(1,:) = src(:)
+       bmi_status = BMI_SUCCESS
+    case("adc2")
+       this%model%parameters%adc(2,:) = src(:)
+       bmi_status = BMI_SUCCESS
+    case("adc3")
+       this%model%parameters%adc(3,:) = src(:)
+       bmi_status = BMI_SUCCESS
+    case("adc4")
+       this%model%parameters%adc(4,:) = src(:)
+       bmi_status = BMI_SUCCESS
+    case("adc5")
+       this%model%parameters%adc(5,:) = src(:)
+       bmi_status = BMI_SUCCESS
+    case("adc6")
+       this%model%parameters%adc(6,:) = src(:)
+       bmi_status = BMI_SUCCESS
+    case("adc7")
+       this%model%parameters%adc(7,:) = src(:)
+       bmi_status = BMI_SUCCESS
+    case("adc8")
+       this%model%parameters%adc(8,:) = src(:)
+       bmi_status = BMI_SUCCESS
+    case("adc9")
+       this%model%parameters%adc(9,:) = src(:)
+       bmi_status = BMI_SUCCESS
+    case("adc10")
+       this%model%parameters%adc(10,:) = src(:)
+       bmi_status = BMI_SUCCESS
+    case("adc11")
+       this%model%parameters%adc(11,:) = src(:)
        bmi_status = BMI_SUCCESS
 
     case default

--- a/src/bmi/bmi_snow17.f90
+++ b/src/bmi/bmi_snow17.f90
@@ -631,6 +631,21 @@ contains
     case("raim")
        size = sizeof(this%model%modelvar%raim_comb)
        bmi_status = BMI_SUCCESS
+    case("scf")
+       size = sizeof(this%model%parameters%scf(1))
+       bmi_status = BMI_SUCCESS
+    case("mfmax")
+       size = sizeof(this%model%parameters%mfmax(1))
+       bmi_status = BMI_SUCCESS
+    case("mfmin")
+       size = sizeof(this%model%parameters%mfmin(1))
+       bmi_status = BMI_SUCCESS
+    case("uadj")
+       size = sizeof(this%model%parameters%uadj(1))
+       bmi_status = BMI_SUCCESS
+    case("si")
+       size = sizeof(this%model%parameters%si(1))
+       bmi_status = BMI_SUCCESS
     case default
        size = -1
        bmi_status = BMI_FAILURE

--- a/src/bmi/bmi_snow17.f90
+++ b/src/bmi/bmi_snow17.f90
@@ -287,6 +287,9 @@ contains
          'precip_scf', 'sneqv', 'snowh', 'raim')   ! output vars
        grid = 0
        bmi_status = BMI_SUCCESS
+    case('scf', 'mfmax', 'mfmin', 'uadj', 'si')       ! parameters
+       grid = 0
+       bmi_status = BMI_SUCCESS
     case default
        grid = -1
        bmi_status = BMI_FAILURE
@@ -556,6 +559,9 @@ contains
     select case(name)
     case('tair', 'precip', &                            ! input/output vars
          'precip_scf', 'sneqv', 'snowh', 'raim')        ! output vars
+       type = "real"
+       bmi_status = BMI_SUCCESS
+    case('scf', 'mfmax', 'mfmin', 'uadj', 'si')       ! parameters
        type = "real"
        bmi_status = BMI_SUCCESS
     case default
@@ -886,6 +892,23 @@ contains
     case("raim")
        this%model%modelvar%raim(1) = src(1)
        bmi_status = BMI_SUCCESS
+    ! parameters
+    case("scf")
+       this%model%parameters%scf(:) = src(:)
+       bmi_status = BMI_SUCCESS
+    case("mfmax")
+       this%model%parameters%mfmax(:) = src(:)
+       bmi_status = BMI_SUCCESS
+    case("mfmin")
+       this%model%parameters%mfmin(:) = src(:)
+       bmi_status = BMI_SUCCESS
+    case("uadj")
+       this%model%parameters%uadj(:) = src(:)
+       bmi_status = BMI_SUCCESS
+    case("si")
+       this%model%parameters%si(:) = src(:)
+       bmi_status = BMI_SUCCESS
+
     case default
        bmi_status = BMI_FAILURE
     end select


### PR DESCRIPTION
This PR adds the minimum functionality needed to calibrate snow17 in nextgen

## Additions

- Add calibration paramters to bmi: scf, mfmax, mfmin, uadj, si, adc1, adc2, adc3, adc4, adc5, adc6, adc7, adc8, adc9, adc10, adc11

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
