### PR TITLE
Revert bmi model name to `libsnow17bmi`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ endif ()
 
 #### Add variables for individual libraries that are used within the *.pc.in files
 # snow17
-set(SNOW_LIB_NAME_CMAKE snow17_bmi)
+set(SNOW_LIB_NAME_CMAKE snow17bmi)
 set(SNOW_STANDALONE_EXE_NAME snow17)
 set(SNOW_LIB_DESC_CMAKE "External Snow17 Shared Library")
 set(PARENT_SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/src/)

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ cmake --build cmake_build --target snow17 # This will build the stand-alone exec
 cmake --build cmake_build                 # This will build the stand-alone executable and the NextGen BMI module shared library
 ```
 
-Once you build the shared library, you should see the shared library in build directory, named `cmake_build/libsnow17_bmi.<version>.so` on Linux systems (on Mac, you will see `.dylib` rather than `.so`).  There will also be `cmake_build/libsnow17_bmi.so` symlink pointing to the shared library file.
+Once you build the shared library, you should see the shared library in build directory, named `cmake_build/libsnow17bmi.<version>.so` on Linux systems (on Mac, you will see `.dylib` rather than `.so`).  There will also be `cmake_build/libsnow17bmi.so` symlink pointing to the shared library file.
 
 ## Getting help
 


### PR DESCRIPTION
The BMI model has been named `libsnow17bmi` since commit 9d1f7f6. This PR reverts the rename to `libsnow17_bmi` introduced in #60 to preserve backward compatibility with existing tools that depend on the original naming convention.