### PR TITLE
docs: correct BMI build target name to (snow17_bmi → snow17bmi)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,10 @@ cmake -B cmake_build -DISO_C_FORTRAN_BMI_PATH=/Users/rbartel/Developer/noaa/ngen
 > The directory to use for ISO_C_FORTRAN_BMI_PATH will generally be `<path_to_your_ngen_repo>/extern/iso_c_fortran_bmi`.  It is assumed that you have already cloned the NextGen repo locally.
 
 
-With this done when the build directory is created, we will also have access to another build target:  `snow17_bmi`.   This is how we build the NextGen BMI module shared library:
+With this done when the build directory is created, we will also have access to another build target:  `snow17bmi`.   This is how we build the NextGen BMI module shared library:
 
 ```bash
-cmake --build cmake_build --target snow17_bmi
+cmake --build cmake_build --target snow17bmi
 ```
 
 > [!NOTE]


### PR DESCRIPTION
## Additions

Corrected the shared-library build target name in README.md (lines 80, 83).

## Removals

Removed references to the non-existent target `snow17_bmi`.

## Testing

1. From a clean clone, confirmed `cmake --build cmake_build --target snow17_bmi`
   fails with "No rule to make target".
2. `cmake --build cmake_build --target help` lists `snow17` and `snow17bmi`;
   there is no `snow17_bmi` target.
3. `cmake --build cmake_build --target snow17bmi` succeeds and produces
   `cmake_build/libsnow17bmi.1.0.0.dylib`.
4. Target name verified against `CMakeLists.txt:37`
   (`set(SNOW_LIB_NAME_CMAKE snow17bmi)`).
5. Environment: macOS 26.5.2 (arm64), GNU Fortran 16.1.0, CMake 4.4.2.

Documentation-only change; no code modified, so no unit tests added.

## Notes

Closes #66 .